### PR TITLE
remove sbp from query, as sbp as some gaps in it

### DIFF
--- a/sql/read_data.sql
+++ b/sql/read_data.sql
@@ -9,12 +9,12 @@ select c.time                            as time,
        delta_mw,
        level_fpn * 0.5                   as level_fpn_mwh,
        level_after_boal * 0.5            as level_after_boal_mwh,
--->        system_buy_price,
+       system_buy_price,
        cost_gbp,
 -->    system_buy_price * delta_mw * 0.5 as turnup_cost_gbp
        200 * delta_mw * 0.5 as turnup_cost_gbp
 from curtailment c
-         --> join sbp s on c.time = s.time
+         left join sbp s on c.time = s.time
 where c.time BETWEEN CAST(%(start_time)s as TIMESTAMP)
     AND CAST(%(end_time)s as TIMESTAMP)
 order by c.time


### PR DESCRIPTION
remove sbp from query, as sbp has some nulls in it. 

The sbp collection script probably needs improvements to run it properly. E.g. look up the last timestamp in the database, then pull from then onwards. 

branch
<img width="729" alt="Screenshot 2023-01-06 at 09 20 06" src="https://user-images.githubusercontent.com/34686298/210970659-c7e13b5f-3bcc-4d16-ba12-59c0f8fa8c30.png">

main
![Screenshot 2023-01-06 at 09 20 24](https://user-images.githubusercontent.com/34686298/210970669-29ce3812-baf6-4b4b-bfba-bfe49994ab60.png)


