### PR TITLE
Update sql for sbp 100

### DIFF
--- a/sql/read_data.sql
+++ b/sql/read_data.sql
@@ -1,7 +1,8 @@
 --> 1. Joins in the `sbp` table with 'curtailment'
 --> 2. Manipulates some columns which used to be manipulated in pandas (faster in SQL)
 --> 3. start and end time are parameters which are interpolated by the SQL engine
---> Note a fixed gass turn up price is used #52
+--> Note a fixed gas turn up price is used #52
+--> Note the gas price is 100, but in 2022 we use 200.
 
 select c.time                            as time,
        level_fpn                         as level_fpn_mw,
@@ -12,7 +13,11 @@ select c.time                            as time,
        system_buy_price,
        cost_gbp,
 -->    system_buy_price * delta_mw * 0.5 as turnup_cost_gbp
-       200 * delta_mw * 0.5 as turnup_cost_gbp
+       CASE
+            WHEN c.time<'2022-01-01' THEN delta_mw * 0.5 * 100
+            WHEN (c.time>='2022-01-01' and c.time<'2023-01-01') THEN delta_mw * 0.5 * 200
+            WHEN c.time>='2023-01-01' THEN delta_mw * 0.5 * 100
+		END AS turnup_cost_gbp
 from curtailment c
          left join sbp s on c.time = s.time
 where c.time BETWEEN CAST(%(start_time)s as TIMESTAMP)


### PR DESCRIPTION
Update the sql so that the gas turn up prices reflects the sbp more
We use 
- 200 in 2022
- 100 in 2021 and 2023 onwards

This fits the average sbp much better.
in 2021 was 113
in 2022 was 201
in 2023 was 94

This gets in more in line with Lorenz analysis - https://www.bbc.co.uk/news/business-67494082, which is £590m. 
Changes from 
![Screenshot 2024-01-04 at 18 33 07](https://github.com/hackcollective/wind-curtailment/assets/34686298/3afd827b-e291-4b51-8386-493a5e8b4bba)

to
![Screenshot 2024-01-04 at 18 32 52](https://github.com/hackcollective/wind-curtailment/assets/34686298/a2371c77-b35b-4d05-81d1-560723cc7eab)
 

I would something in our methodlolgy like

We already have `- SIP (System Imbalance Prices, or System Buy Prices)
    - We use these to estimate the cost of turning up alternative generation to offset curtailed wind`
 I would add
`Specifcialy we use £100 per MWh in 2021, 2100 per MWh in 2022, and £100 per MWh from 2023 onwards. `

We have used 