### PR TITLE
fixes for 00:00 and not loading enough BOAs

### DIFF
--- a/lib/curtailment.py
+++ b/lib/curtailment.py
@@ -254,10 +254,11 @@ def analyze_curtailment(db: DbRepository, start_time, end_time) -> pd.DataFrame:
     df_curtailment["Level_BOAL"] = df_curtailment["Level_BOAL"] / 30
     df_curtailment["Level_FPN"] = df_curtailment["Level_FPN"] / 30
 
-    # remove anything after the end_datetime
-    end_time = pd.to_datetime(end_time)
-    end_time = add_utc_timezone(end_time)
+    # remove anything after the start and end datetime
+    end_time = add_utc_timezone(pd.to_datetime(end_time))
+    start_time = add_utc_timezone(pd.to_datetime(start_time))
     df_curtailment = df_curtailment[df_curtailment["Time"] < pd.to_datetime(end_time)]
+    df_curtailment = df_curtailment[df_curtailment["Time"] >= pd.to_datetime(start_time)]
 
     assert "cost_gbp" in df_curtailment.columns
     assert "energy_mwh" in df_curtailment.columns

--- a/lib/curtailment.py
+++ b/lib/curtailment.py
@@ -260,6 +260,9 @@ def analyze_curtailment(db: DbRepository, start_time, end_time) -> pd.DataFrame:
     df_curtailment = df_curtailment[df_curtailment["Time"] < pd.to_datetime(end_time)]
     df_curtailment = df_curtailment[df_curtailment["Time"] >= pd.to_datetime(start_time)]
 
+    # reset index
+    df_curtailment.reset_index(drop=True, inplace=True)
+
     assert "cost_gbp" in df_curtailment.columns
     assert "energy_mwh" in df_curtailment.columns
     assert "delta" in df_curtailment.columns

--- a/lib/data/fetch_boa_data.py
+++ b/lib/data/fetch_boa_data.py
@@ -205,11 +205,10 @@ def call_physbm_api(start_date, end_date, unit=None):
     data_df = []
     for datetime in datetimes:
         logger.info(f"Getting PN from {datetime}")
-        date = datetime.date()
 
         datetime = add_utc_timezone(datetime)
 
-        sp = dt2sp(datetime)[1]
+        date, sp = dt2sp(datetime)
         url = f"https://data.elexon.co.uk/bmrs/api/v1/balancing/physical/all?dataset=PN&settlementDate={date}&settlementPeriod={sp}"
         if unit is not None:
             url = url + f"&bmUnit={unit}"

--- a/lib/data/fetch_boa_data.py
+++ b/lib/data/fetch_boa_data.py
@@ -226,8 +226,8 @@ def call_physbm_api(start_date, end_date, unit=None):
     for datetime in datetimes:
         logger.info(f"Getting BOALF from {datetime}")
         boalf_end_datetime = (datetime + pd.Timedelta(minutes=30)).tz_localize(None)
-        datetime_no_timezone = datetime.tz_localize(None)
-        url = f"https://data.elexon.co.uk/bmrs/api/v1/datasets/BOALF?from={datetime_no_timezone}&to={boalf_end_datetime}"
+        boalf_start_datetime = (datetime - pd.Timedelta(minutes=30)).tz_localize(None)
+        url = f"https://data.elexon.co.uk/bmrs/api/v1/datasets/BOALF?from={boalf_start_datetime}&to={boalf_end_datetime}"
         if unit is not None:
             url = url + f"&bmUnit={unit}"
         url = url + "&format=json"

--- a/lib/db_utils.py
+++ b/lib/db_utils.py
@@ -67,6 +67,9 @@ class DbRepository:
         logger.debug(f"{start_time=}")
         logger.debug(f"{end_time=}")
 
+        # load 30 minutes more
+        start_time = pd.to_datetime(start_time) - pd.Timedelta(minutes=30)
+
         with self.engine.connect() as conn:
             logger.debug(f"Getting FPNs from {start_time} to {end_time}")
             df_fpn = pd.read_sql(
@@ -89,6 +92,7 @@ class DbRepository:
                 index_col="bmUnitID",
                 parse_dates=["timeFrom", "timeTo"],
             )
+
             logger.info(f"Found {len(df_fpn)} FPNs")
             logger.info(f"Found {len(df_boal)} BOAs")
             logger.info(f"Found {len(df_bod)} BODs")

--- a/tests/data/test_fetch_fpn_data.py
+++ b/tests/data/test_fetch_fpn_data.py
@@ -39,5 +39,5 @@ def test_fetch_fpn_data():
             parse_dates=["timeFrom", "timeTo"],
         )
 
-    assert len(df_boa) == 147
-    assert len(df_fpn) == 3178
+    assert len(df_boa) == 215
+    assert len(df_fpn) == 3010

--- a/tests/data/test_main.py
+++ b/tests/data/test_main.py
@@ -15,8 +15,8 @@ def test_fetch_and_load_data():
     assert df["level_after_boal"].mean() > 13000
     assert df["level_after_boal"].mean() < 15000
 
-    assert df["cost_gbp"].mean() >= 40000
-    assert df["cost_gbp"].mean() <= 50000
+    assert df["cost_gbp"].mean() >= 50000
+    assert df["cost_gbp"].mean() <= 60000
 
     assert pd.to_datetime(df['time'][0]) == pd.Timestamp("2024-04-06 06:00:00+01:00")
 


### PR DESCRIPTION
Two fixes

- Every day at 00:00 the date was 0, this was a fix due to sp and date
- Fix due to zig-zag shape of BOAs. This was due to BOAs not being counted that started before the hour, and etl pulling data in hour chunks. We had accounted for BOAs that finished after the hour

both bugs are fixed locally, you can see both bugs below

<img width="835" alt="Screenshot 2024-06-03 at 18 36 56" src="https://github.com/hackcollective/wind-curtailment/assets/34686298/fc958230-dfe6-4e46-abdb-7be854231873">
